### PR TITLE
Two-pass parse to fix labels

### DIFF
--- a/defense.bot
+++ b/defense.bot
@@ -29,13 +29,13 @@ p0_lefttop:
 #page 10
 	build 1
 	trans 11, 0
-	trans 13, 8
+	trans 13, 13
 	trans 15, 15
 	wake
 	rot 1
 	build 1
 	trans 12, 0
-	trans 13, 8
+	trans 13, 13
 	trans 15, 15
 	wake
 	rot -1
@@ -72,7 +72,7 @@ p0_lefttop:
 
 
 
-#page 13 //child page 8
+#page 13
 	look ahead
 	goto _rip+1+ahead
 	goto @p13_rotate_contemplate //0 nothing -- just turn...

--- a/killer.bot
+++ b/killer.bot
@@ -6,9 +6,8 @@
 	trans 1, 0
 	page 2
 #page 1
-loop:
 	suicide
-	goto @loop
+	goto _rip-1
 #page 2
 dance:
 	rotate 1

--- a/look.bot
+++ b/look.bot
@@ -54,12 +54,7 @@ mybot:
 
 
 myawake:
-	sto p, 0
-Mtransloop:
-	trans 8, p
-	sto p, p+1
-	look ahead
-	ifgoto ahead==6&&p<16, @Mtransloop
+	trans 8, 8
 	goto @start
 
 


### PR DESCRIPTION
When copying pages to a bot of a different team/program/player (all equivalent), labels would mess up because they were looked up in the _program_, not somewhere in the bot itself. These commits attempt to fix that by making the system a bit more pragmatic.
